### PR TITLE
feat(clipboard): add operations with tests and fix module path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ xinerama = []
 clipboard = []
 
 [dependencies]
+
+[workspace]
+members = ["examples/*"]

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -336,8 +336,8 @@ impl<T> Display<T> where T: Send + Sync + Read + Write + TryClone + 'static {
     /// get the clipboard interface
 
     #[cfg(feature = "clipboard")]
-    pub fn clipboard(&mut self) -> Result<Clipboard<T>, Error> {
-        Clipboard::new(self.clone())
+    pub fn clipboard(&mut self) -> Result<crate::clipboard::Clipboard<T>, Error> {
+        crate::clipboard::Clipboard::new(self.clone())
     }
 
     /// wait for the next event

--- a/tests/test_clipboard.rs
+++ b/tests/test_clipboard.rs
@@ -1,0 +1,49 @@
+#[cfg(feature = "clipboard")]
+mod tests {
+
+    use std::time::SystemTime;
+
+    use yaxi::{self, display};
+
+    #[test]
+    fn test_clipboard_read_text() {
+        let mut display = display::open_unix(0).unwrap();
+        let mut clipboard = display.clipboard().unwrap();
+
+        let result = clipboard.get_text();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_clipboard_write_text() {
+        let mut display = display::open_unix(0).unwrap();
+        let mut clipboard = display.clipboard().unwrap();
+
+        let now = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        let excepted = format!("test {}", now);
+
+        let result = clipboard.set_text(&excepted);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_clipboard_text_consistency() {
+        let mut display = display::open_unix(0).unwrap();
+        let mut clipboard = display.clipboard().unwrap();
+
+        let time = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        let excepted = format!("test-{}", time);
+
+        let result = clipboard.set_text(&excepted);
+        assert!(result.is_ok());
+
+        let text = clipboard.get_text().unwrap();
+        assert_eq!(excepted, text);
+    }
+}


### PR DESCRIPTION
This PR includes several improvements to the clipboard functionality:

### Features
- Enable rust-analyzer support for examples

### Tests
- Add unit tests for clipboard module
- Add test cases for text operations

### Fixes
- Correct module path for `Clipboard` to fix compilation issues

Let me know if you'd like me to add more test cases or make any adjustments to the implementation.