### PR TITLE
Feature/clipboard types

### DIFF
--- a/examples/clipboard/src/copy.rs
+++ b/examples/clipboard/src/copy.rs
@@ -1,7 +1,7 @@
 use yaxi::clipboard::Clipboard;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut clipboard = Clipboard::new(None)?;
+    let clipboard = Clipboard::new(None)?;
 
     clipboard.set_text("test 123")?;
 

--- a/examples/clipboard/src/owners.rs
+++ b/examples/clipboard/src/owners.rs
@@ -1,7 +1,7 @@
 use yaxi::display;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut display = display::open(None)?;
+    let display = display::open(None)?;
 
     let selections = [
         display.intern_atom("PRIMARY", false)?,

--- a/examples/clipboard/src/paste.rs
+++ b/examples/clipboard/src/paste.rs
@@ -1,7 +1,7 @@
 use yaxi::clipboard::Clipboard;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut clipboard = Clipboard::new(None)?;
+    let clipboard = Clipboard::new(None)?;
 
     let text = clipboard.get_text()?;
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -177,6 +177,21 @@ impl Atom {
     }
 }
 
+impl TryFrom<&[u8]> for Atom {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Atom, Error> {
+        match bytes.len() {
+            4 => {
+                let ne_bytes = bytes.try_into().map_err(|_| Error::InvalidAtom)?;
+                let id = u32::from_ne_bytes(ne_bytes);
+                Ok(Atom::new(id))
+            }
+            _ => Err(Error::InvalidAtom),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Visual {
     pub id: u32,

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -443,12 +443,12 @@ impl Display {
     }
 
     /// get an atom from its name
-    pub fn intern_atom<'a>(&self, name: &'a str, only_if_exists: bool) -> Result<Atom, Error> {
+    pub fn intern_atom(&self, name: &str, only_if_exists: bool) -> Result<Atom, Error> {
         self.sequence.append(ReplyKind::InternAtom)?;
 
         let request = InternAtom {
             opcode: Opcode::INTERN_ATOM,
-            only_if_exists: only_if_exists.then(|| 1).unwrap_or(0),
+            only_if_exists: if only_if_exists { 1 } else { 0 },
             length: 2 + (name.len() as u16 + request::pad(name.len()) as u16) / 4,
             name_len: name.len() as u16,
             pad1: [0u8; 2],


### PR DESCRIPTION
chore: Update examples
feat: Add  `impl TryFrom<&[u8]> for Atom`
chore: Remove unnecessary lifecycle markers
feat: Clipboard support to read more types(text, html, rtf, targets...)